### PR TITLE
Do not set ha-card elements transparent

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -144,14 +144,12 @@ class VerticalStackInCard extends HTMLElement {
             } else {
                 let ele = element.shadowRoot.querySelector('ha-card')
                 ele.style.boxShadow = 'none';
-                ele.style.background = 'transparent';
                 ele.style.borderRadius = '0';
             }
         } else {
             if (typeof element.querySelector === 'function' && element.querySelector('ha-card')) {
                 let ele = element.querySelector('ha-card')
                 ele.style.boxShadow = 'none';
-                ele.style.background = 'transparent';
                 ele.style.borderRadius = '0';
             }
             let searchEles = element.childNodes;


### PR DESCRIPTION
Stop setting ha-card elements to transparent automatically.

The current setting overrides styles set in other cards (notably custom:button-card). Automatically setting transparency should generally not be necessary, since most cards all have the same background. If they don't (or if the background is an image), card-mod can be used to set transparency.

As it stands now, the Javascript automatically changes any background that someone might have set to their card (and there's no way to override it, save for adding in more Javascript).