### PR TITLE
Fix for Issue #80; Cards all stacked in a Single Column

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -153,13 +153,11 @@ class VerticalStackInCard extends HTMLElement {
 
   getCardSize() {
     let promise = new Promise((resolve, reject) => {
-      if (this._refCards.length == this._config.cards.length) {
-        let totalSize = 0;
-        this._refCards.forEach((element) => {
-          totalSize += typeof element.getCardSize === 'function' ? element.getCardSize() : 1;
-        });
-        resolve(totalSize);
-      }
+      let totalSize = 0;
+      this._refCards.forEach((element) => {
+        totalSize += typeof element.getCardSize === 'function' ? element.getCardSize() : 1;
+      });
+      resolve(totalSize);
     });
    return promise;
   }

--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -152,11 +152,16 @@ class VerticalStackInCard extends HTMLElement {
   }
 
   getCardSize() {
-    let totalSize = 0;
-    this._refCards.forEach((element) => {
-      totalSize += typeof element.getCardSize === 'function' ? element.getCardSize() : 1;
+    let promise = new Promise((resolve, reject) => {
+      if (this._refCards.length == this._config.cards.length) {
+        let totalSize = 0;
+        this._refCards.forEach((element) => {
+          totalSize += typeof element.getCardSize === 'function' ? element.getCardSize() : 1;
+        });
+        resolve(totalSize);
+      }
     });
-    return totalSize;
+   return promise;
   }
 }
 


### PR DESCRIPTION
Return a promise for getCardSize so that the value is not
calculated until the "child" cards are created and their size
is known.

This patch requires HomeAssistant version 0.110 or greater.

I am no JS expert, so I very well may have done something silly
in here.

Fixes #80