### PR TITLE
card is not encapsulated in shadowRoot causing card mod styles to collide

### DIFF
--- a/vertical-stack-in-card.js
+++ b/vertical-stack-in-card.js
@@ -48,10 +48,12 @@ class VerticalStackInCard extends HTMLElement {
       });
     }
     card.appendChild(cardContent);
-    while (this.hasChildNodes()) {
-      this.removeChild(this.lastChild);
+    
+    const shadowRoot = this.shadowRoot || this.attachShadow({mode: 'open'});
+    while (shadowRoot.hasChildNodes()) {
+      shadowRoot.removeChild(shadowRoot.lastChild);
     }
-    this.appendChild(card);
+    shadowRoot.appendChild(card);
 
     // Calculate card size
     this._cardSize.resolve();


### PR DESCRIPTION
This PR encapsulated the created card in side a shadowRoot. This is required when using card-mod to add custom styles to the card, which adds a `<style>` element that, if not inside a shadowRoot, will affect the entire view.

@ofekashery can you please CR?